### PR TITLE
CORCI-918 build: Create trusted library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,51 @@
+#!/usr/bin/env groovy
+/* Copyright (C) 2019-2020 Intel Corporation
+ * All rights reserved.
+ *
+ * This file is part of the DAOS Project. It is subject to the license terms
+ * in the LICENSE file found in the top-level directory of this distribution
+ * and at https://img.shields.io/badge/License-Apache%202.0-blue.svg.
+ * No part of the DAOS Project, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ */
+
+// The @library line needs to be edited in a PR for adding a test.
+// Adding a test requires two PRs.  One to add the test.
+// That PR should be landed with out deleting the PR branch.
+// Then a second PR submitted to comment out the @Library line, and when it
+// is landed, both PR branches can be deleted.
+
+// @Library(value="pipeline-lib@my_pr_branch") _
+@Library(value="trusted-pipeline-lib@corci-918") _
+
+pipeline {
+  agent { label 'lightweight' }
+  stages {
+    stage('Cancel Previous Builds') {
+      when { changeRequest() }
+      steps {
+        cancelPreviousBuilds()
+      }
+    } // stage('Cancel Previous Builds')
+
+    stage ('Test') {
+      steps {
+        sh label: 'Pragma test',
+           script: 'sleep ' +
+                    commitPragmaTrusted(pragma: 'Sleep-minutes',
+                                        def_val: '1')
+      } // steps
+    } // stage ('Test')
+  } //stages
+  post {
+    success {
+      scmNotifyTrusted context: 'JENKINS',
+                       status: 'SUCCESS'
+      }
+      unsuccessful {
+        scmNotifyTrusted context: 'JENKINS',
+                         status: 'FAILURE'
+      }
+    } // post
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,118 @@
 # trusted-pipeline-lib
+
 Global pipeline library used for common routines
+
+This library is for these main purposes.
+
+* Common Code that is used for multiple pipeline projects including
+  the unit testing of the methods in a pipeline library.
+
+* Routines that need groovy methods that are not white listed by Jenkins.
+
+## Usage
+
+This library or a fork of it that implements the routines in it needs to be
+installed on the Jenkins system as a global pipeline library.
+
+The global variables also known to Jenkins as "steps" in this library have the
+suffix 'Trusted' on them as both an attempt to prevent name space colisions
+with other pipeline libraries, and also to indicate that this library
+contained the global symbol.
+
+### Global Variables or Steps Provided
+
+#### cancelPreviousBuildsTrusted
+
+This is step to allow a Jenkins job to cancel a build job that has been
+superceeded by a later commit.
+
+It takes no parameters and has no return value.
+
+#### commitPragmaTrusted
+
+This is a step to look at the GIT commit message for special instructions
+known as pragmas have been set.
+
+~~~groovy
+  def skip_stage(String stage) {
+    return commitPragmaTrusted(pragma: 'Skip-' + stage) == 'true'
+  }
+
+  TEST_RPMS = commitPragmaTrusted(pragma: 'RPM-test', def_val: 'false')
+~~~
+
+These pragmas can be used control what Jenkins steps or CI tests are run.
+
+A pragma consist of a name value pair.  The name portition starts at the
+beginning of a line, has no spaces in it, and ends with a colon character.
+
+The value string is preceeded by a least one space after the colon, and
+should also not have any white space in it.
+
+The return value is the string from the pragma, or an empty string if the
+pragma is not set and no default value is provided.
+
+This step takes a map of with these member names:
+
+##### def_val
+
+A string for the default value to be used if the pragma is not present.
+This parameter is optional.  The default is an empty string.
+
+##### pragma
+
+A string for the pragma name.  No spaces in the name.  The trailing colon
+is not specified.
+
+#### scmNotifyTrusted
+
+This is a simplified wrapper for the gitHubNotify to also allow supporting
+alternate SCM systems such as GitLab.
+
+This step has no return value.
+
+This step takes a map with these member names:
+
+##### context
+
+This a string used by the SCM system to track status changes.  Each stage
+that reports status needs a different string.
+
+Default is "build/${env.STAGE_NAME}".
+
+The default value can not be used for a Matrix stage.
+
+##### credentialsID
+
+This is a Jenkins Credential ID that needs to be provided for GitHub
+status updates.
+
+If one is not provided, this routine will lookup the environment variable
+SCM_COMMIT_STATUS_ID that will need to be set in Jenkins and use it.
+
+If no Credential ID is provided as a parameter, or can be looked up in an
+environment variable, then a message will be logged that the jenkins system
+is not configured to notify the scm.
+
+##### Description
+
+This is a human readable text that can be displayed by the SCM system.
+Not used for GitLab.
+
+Default is "${env.STAGE_NAME}"
+
+The default value should probably not be used for a Matrix stage.
+
+##### status
+
+Required parameter.  Should be one of 'PENDING', 'SUCCESS', 'FAILURE' or
+'ERROR'.
+
+This will be translated for GitLab.
+
+##### targetUrl
+
+Optional parameter to add a target URL in the notification that will be
+provided as a link.
+
+Not used for GitLab.

--- a/src/com/intel/cancelPreviousBuildsInternal.groovy
+++ b/src/com/intel/cancelPreviousBuildsInternal.groovy
@@ -1,0 +1,35 @@
+// src/com/intel/cancelPreviousBuildsInternal.groovy
+
+package com.intel
+
+/**
+ * cancelPreviousBuildsInternal.groovy
+ *
+ * Routine to cancel old builds in progress
+ */
+
+
+def cancelPreviousBuildsInternal(Map config = [:]) {
+  /**
+   * Cancel old builds method.
+   *
+   * @param config Map of parameters passed (currently none)
+   * @return Nothing
+   */
+
+  def jobName = env.JOB_NAME
+  def buildNumber = env.BUILD_NUMBER.toInteger()
+  /* Get job name */
+  def currentJob = Jenkins.instance.getItemByFullName(jobName)
+
+  /* Iterating over the builds for specific job */
+  for (def build : currentJob.builds) {
+    /* If there is a build that is currently running and it's not current build */
+    if (build.isBuilding() && build.number.toInteger() < buildNumber) {
+      print "Stopping currently running build #${build.number}"
+      /* Than stopping it */
+      build.doStop()
+    }
+  }
+
+}

--- a/vars/cancelPreviousBuildsTrusted.groovy
+++ b/vars/cancelPreviousBuildsTrusted.groovy
@@ -1,0 +1,14 @@
+// vars/cancelPreviousBuildsInternal.groovy
+
+import com.intel.cancelPreviousBuildsInternal
+
+def call(Map config = [:]) {
+  /**
+   * Cancel previous builds of the current job
+   *
+   * @param config Map of parameters passed (none currently)
+   * @return Nothing
+   */
+  def c = new com.intel.cancelPreviousBuildsInternal()
+  return c.cancelPreviousBuildsInternal(config)
+}

--- a/vars/commitPragmaTrusted.groovy
+++ b/vars/commitPragmaTrusted.groovy
@@ -1,0 +1,29 @@
+// vars/commitPragmaTrusted.groovy
+
+/**
+ * Method to get a commit pragma value
+ *
+ *
+ * @param config Map of parameters passed.
+ *
+ * config['pragma']     Pragma to get the value of
+ * config['def_val']    Value to return if not found
+ */
+def call(Map config = [:]) {
+
+    def def_value = ''
+    if (config['def_val']) {
+        def_value = config['def_val']
+    }
+    def value = sh(script: '''b=$(git show -s --format=%B |
+                                  sed -ne 's/^''' + config['pragma'] +
+                           ''': *\\(.*\\)/\\1/p')
+                              if [ -n "$b" ]; then
+                                  echo "$b"
+                              else
+                                  echo "''' + def_value + '''"
+                              fi''',
+                returnStdout: true)
+    return value.trim()
+
+}

--- a/vars/scmNotifyTrusted.groovy
+++ b/vars/scmNotifyTrusted.groovy
@@ -1,0 +1,72 @@
+// vars/scmNotifyTrusted.groovy
+
+/**
+ * Simplified scmNotifyTrusted command for GitHub/Gitlab
+ * 
+ * Mimics the notifyGithub API for use with either GitHub or GitLab.
+ *
+ * @param config Map of parameters passed.
+ *
+ * config['status']      Status text.  Required.
+ *                       Should be one of 'PENDING','SUCCESS','FAILURE',
+ *                       or 'ERROR'.
+ *                       For GitLab, this will be translated to 'pending',
+ *                       'success', or 'failed'.
+ * config[credentialsId] Jenkins credential ID that should be used for
+ *                       notifying the SCM repository.
+ *                       Not used for GitLab.
+ * config['description'] Description text for notification.
+ *                       Human readable text.
+ *                       Default is "${env.STAGE_NAME}"
+ *                       Do not use a default for a Matrix Stage.
+ *                       Not used for GitLab.
+ * config['context']     Context for the notification.
+ *                       This is used by GitHub/GitLab to track status
+ *                       changes.
+ *                       Default is "build/${env.STAGE_NAME}".
+ *                       Do not use a default for a Matrix Stage.
+ * config['targetUrl']   Target URL for notification if present.
+ *                       Not used for GitLab.
+ */
+def call(Map config = [:]) {
+
+  if (!config['status']) {
+    error 'scmNotifySystem needs a status parameter value!'
+  }
+
+  def is_github = false
+  def is_gitlab = false
+  if (env.GIT_URL) {
+    // First thing is to determine if this is GitHub or GitLab
+    is_github = env.GIT_URL.contains('.github.com/')
+    is_gitlab = env.GIT_URL.contains('gitlab')
+  }
+  Map params = [:]
+
+  if (is_github) {
+    if (config['credentialsId']) {
+      param['credentialsId'] = config['credentialsId']
+    } else {
+      if (env.SCM_COMMIT_STATUS_ID) {
+        param['credentialsId'] = env.SCM_COMMIT_STATUS_ID
+      } else {
+        steps.println ('Jenkins not configured to notify GitLab')
+      }
+    }
+    params['description'] = config.get('description', env.STAGE_NAME)
+    params['context'] = config.get('context', "build/" + env.STAGE_NAME)
+    params['status'] = config['status']
+    if (config['targetUrl']) {
+      params['targetUrl'] = config['targetUrl']
+    }
+    steps.githubNotify params
+  }
+  if (is_gitlab) {
+    params['state'] = config['status'].toLowerCase()
+    if ((params['state'] == 'failure') || (params['state'] == 'error')) {
+        params['state'] = 'failed'
+    }
+    params['name'] = config.get('context', "build/" + env.STAGE_NAME)
+    steps.updateGitlabCommitStatus params
+  }
+}


### PR DESCRIPTION
This is the start of a generic trusted library for Jenkins.

It is intended to contain generic routines that are either common many Jenkins
projects or use methods that are not allowed in a Jenkins groovy sand
box.

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>