### PR TITLE
Add daosLatestVersion() to trusted pipeline-lib

### DIFF
--- a/vars/commitPragmaTrusted.groovy
+++ b/vars/commitPragmaTrusted.groovy
@@ -1,3 +1,4 @@
+/* groovylint-disable ParameterName, VariableName */
 // vars/commitPragmaTrusted.groovy
 
 /**
@@ -9,23 +10,23 @@
  * config['pragma']     Pragma to get the value of
  * config['def_val']    Value to return if not found
  */
-def call(Map config = [:]) {
+String call(Map config = [:]) {
         // convert the map for compat
     return commitPragmaTrusted(config['pragma'], config['def_val'])
 }
 
-def call(String name, String def_val = null) {
+String call(String name, String def_val = null) {
 /**
  * @param name       Pragma to get the value of
  * @param def_val    Value to return if not found
  */
 
-    def def_value = ''
+    String def_value = ''
     if (def_val) {
         def_value = def_val
     }
 
-    String commit_message=""
+    String commit_message = ""
     /* TODO: Replace all of this with currentBuild->changeSets
      *       https://build.hpdd.intel.com/pipeline-syntax/globals#currentBuild
      *       Something along the lines of:
@@ -45,7 +46,7 @@ def call(String name, String def_val = null) {
                             returnStdout: true).trim()
     }
     return sh(script: 'b=$(echo "' + commit_message.replaceAll('"', '\\\\"') +
-                    '''" | sed -ne 's/^''' + name +
+                    '''" | sed -ne 's/^''' + name.replaceAll('/', '\\\\/') +
                     ''': *\\(.*\\)/\\1/Ip')
                        if [ -n "$b" ]; then
                            echo "$b"

--- a/vars/daosLatestVersion.groovy
+++ b/vars/daosLatestVersion.groovy
@@ -1,0 +1,55 @@
+/* groovylint-disable DuplicateNumberLiteral, ParameterName, VariableName */
+// vars/daosLatestVersion.groovy
+
+  /**
+   * daosLatestVersion step method
+   *
+   * @param version search ceiling
+   * @param repository type
+   */
+
+String call(String next_version='1000', String repo_type='stable') {
+    BigDecimal _next_version
+    if (next_version == null) {
+        _next_version = 1000
+    } else {
+        try {
+            // Test if it's already a number
+            _next_version = new BigDecimal(next_version)
+        } catch (NumberFormatException e) {
+            // Must be a branch name, convert to a number
+            switch (next_version) {
+                case 'master':
+                    _next_version = 1000
+                    break
+                 case 'release/2.2':
+                    _next_version = 2.3
+                    break
+                 case 'release/2.0':
+                    _next_version = 2.1
+                    break
+                 default:
+                    error("Don't know what the latest version is for ${branch}")
+            }
+        }
+    }
+
+    String v = null
+    try {
+        v = sh(label: 'Get RPM packages version',
+               script: '$(command -v dnf) repoquery --repofrompath=daos,' + env.ARTIFACTORY_URL +
+                       '/artifactory/daos-stack-daos-el-8-x86_64-stable-local/' +
+                     ''' --repoid daos --qf %{version}-%{release} --whatprovides 'daos-tests(x86-64) < ''' +
+                                  _next_version + '''' |
+                              rpmdev-sort | tail -1''',
+               returnStdout: true).trim()
+    /* groovylint-disable-next-line CatchException */
+    } catch (Exception e) {
+        sh(label: 'Get debug info',
+           script: 'hostname; pwd; df -h /var/cache; lsb_release -a || true')
+        println('Error getting latest daos version.')
+        throw e
+    }
+
+    return v[0..<v.lastIndexOf('.')]
+}


### PR DESCRIPTION
Because scripts not permitted to use
new java.math.BigDecimal java.lang.String.

Escape / in commit pragmas.

Fix linting errors.

Use dnf repoquery if available as YUM's repoquery breaks if run in
parallel.

Use artifactory.