### PR TITLE
SRE-1686 test: Drop arch in latest version query

### DIFF
--- a/vars/daosLatestVersion.groovy
+++ b/vars/daosLatestVersion.groovy
@@ -42,7 +42,7 @@ String call(String next_version='1000', String repo_type='stable') {
         v = sh(label: 'Get RPM packages version',
                script: 'dnf --refresh repoquery --repofrompath=daos,' + env.ARTIFACTORY_URL +
                        '/artifactory/daos-stack-daos-el-8-x86_64-stable-local/' +
-                     ''' --repoid daos --qf %{version}-%{release} --whatprovides 'daos-tests(x86-64) < ''' +
+                     ''' --repoid daos --qf %{version}-%{release} --whatprovides 'daos-tests < ''' +
                                   _next_version + '''' |
                               rpmdev-sort | tail -1''',
                returnStdout: true).trim()


### PR DESCRIPTION
Since the rpmlinting changes went to daos master daos-tests is a noarch package.  So drop the arch in the query for the latest version.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>