### PR TITLE
SRE-2931 build: Fix artifactory url

### DIFF
--- a/vars/daosLatestVersion.groovy
+++ b/vars/daosLatestVersion.groovy
@@ -34,9 +34,8 @@ String getLatestVersion(String distro, BigDecimal next_version, String type='sta
     try {
         v = sh(label: 'Get RPM packages version for: ' + repo + ' with version < ' + next_version.toString(),
                script: '$(command -v dnf) --refresh repoquery --repofrompath=daos,' + env.ARTIFACTORY_URL +
-                       '/artifactory/' + repo +
-                     ''' --repoid daos --qf %{version}-%{release} --whatprovides 'daos < ''' +
-                                  next_version + '''' | rpmdev-sort | tail -1''',
+                       repo + ''' --repoid daos --qf %{version}-%{release} --whatprovides 'daos < ''' +
+                       next_version + '''' | rpmdev-sort | tail -1''',
                returnStdout: true).trim()
     /* groovylint-disable-next-line CatchException */
     } catch (Exception e) {


### PR DESCRIPTION
The env.ARTIFACTORY_URL includes 'artifactory' and does not need to be appended to the variable.