### PR TITLE
SRE-3030 ci: dnf repoquery with explicit \n

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,6 @@
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
 //@Library(value="trusted-pipeline-lib@my_pr_branch") _
-@Library(value="trusted-pipeline-lib@sre-3030") _
 
 /* groovylint-disable-next-line CompileStatic */
 pipeline {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
 //@Library(value="trusted-pipeline-lib@my_pr_branch") _
+@Library(value="trusted-pipeline-lib@sre-3030") _
 
 /* groovylint-disable-next-line CompileStatic */
 pipeline {

--- a/vars/daosLatestVersion.groovy
+++ b/vars/daosLatestVersion.groovy
@@ -39,7 +39,7 @@ String getLatestVersion(String distro, BigDecimal next_version, String type='sta
     try {
         v = sh(label: 'Get RPM packages version for: ' + repo + ' with version < ' + next_version.toString(),
                script: '$(command -v dnf) --refresh repoquery --repofrompath=daos,' + artifactory_url + '/' +
-                       repo + ''' --repoid daos --qf %{version}-%{release} --whatprovides 'daos < ''' +
+                       repo + ''' --repoid daos --qf "%{version}-%{release}\n" --whatprovides 'daos < ''' +
                        next_version + '''' | rpmdev-sort | tail -1''',
                returnStdout: true).trim()
     /* groovylint-disable-next-line CatchException */

--- a/vars/trustedPipelineUnitTests.groovy
+++ b/vars/trustedPipelineUnitTests.groovy
@@ -16,7 +16,6 @@ void _run_unit_tests() {
     // Run all the unit tests
     println('Test daosLatestVersion()')
     _test_daosLatestVersion("master", "el8", /2.7\.\d++.*/)
-    _test_daosLatestVersion('release/2.4', 'el8', /2.[34]\.\d++.*/)
     _test_daosLatestVersion('release/2.6', 'el8', /2.[56]\.\d++.*/)
 }
 


### PR DESCRIPTION
The new version of `dnf` (v.5) on Jenkins runner (fox-108) generates a different result of the `repoquery` command - all results are in one line.
```
/usr/bin/dnf --refresh repoquery --repofrompath=daos,https://.../daos-stack-daos-el-8-x86_64-stable-local/ --repoid daos --qf %{version}-%{release} --whatprovides 'daos < 1000' | rpmdev-sort | tail -1
Updating and loading repositories:
 daos                                   100% |  32.3 KiB/s |   1.1 KiB |  00m00s
Repositories loaded.
2.6.3-7.10921.g582de560.el8n2.6.3-7.10922.g5bd7316a.el8n2.6.3-8.10925.g85f7c886.el8n2.6.3-8.10926.gf1377d3f.el8n2.7.101-8.11208.g3d9eed5b.el8n2.7.101-8.11210.g29c77622.el8n2.7.101-8.11213.g4bce0c27.el8n2.7.101-8.11214.gdacee453.el8n2.7.101-8.3398.g4bce0c27.el8n2.7.101-9.11215.ga6a74827.el8n2.7.101-9.11218.g2b230266.el8n2.7.101-9.11219.g53a48bdf.el8n
```
An explicit `\n` character is required to get the results on separate lines.
```
/usr/bin/dnf --refresh repoquery --repofrompath=daos,https://.../daos-stack-daos-el-8-x86_64-stable-local/ --repoid daos --qf "%{version}-%{release}\n" --whatprovides 'daos < 1000' | rpmdev-sort | tail -1
Updating and loading repositories:
 daos                                   100% |  31.4 KiB/s |   1.1 KiB |  00m00s
Repositories loaded.
2.7.101-9.11219.g53a48bdf.el8
```

Signed-off-by: Tomasz Gromadzki <tomasz.gromadzki@hpe.com>