### PR TITLE
Make master the default branch again - prerequest

### DIFF
--- a/vars/daosLatestVersion.groovy
+++ b/vars/daosLatestVersion.groovy
@@ -34,8 +34,9 @@ String getLatestVersion(String distro, BigDecimal next_version, String type='sta
     try {
         v = sh(label: 'Get RPM packages version for: ' + repo + ' with version < ' + next_version.toString(),
                script: '$(command -v dnf) --refresh repoquery --repofrompath=daos,' + env.ARTIFACTORY_URL +
-                       repo + ''' --repoid daos --qf %{version}-%{release} --whatprovides 'daos < ''' +
-                       next_version + '''' | rpmdev-sort | tail -1''',
+                       '/artifactory/' + repo +
+                     ''' --repoid daos --qf %{version}-%{release} --whatprovides 'daos < ''' +
+                                  next_version + '''' | rpmdev-sort | tail -1''',
                returnStdout: true).trim()
     /* groovylint-disable-next-line CatchException */
     } catch (Exception e) {


### PR DESCRIPTION
A main branch has been created to keep track of all the changes needed for the FC lab.
The master branch was used to keep the old lab going.

Now that the transition process has been finished, we can switch the CI infrastructure back to the 'master' branch and get rid of the 'main' branch, which is confusing.

This PR revert changes to make clean PR (#32) from `main` to `master`