### PR TITLE
Make master the default branch again

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,6 +79,11 @@ Sleep-seconds: 2'''
                 }
             } // steps
         } //stage('env.COMMIT_MESSAGE pragma test')
+        stage('Unit tests') {
+            steps{
+                trustedPipelineUnitTests()
+            }
+        } // stage('Unit tests')
         stage('DAOS Build and Test') {
             when {
                 beforeAgent true

--- a/vars/daosLatestVersion.groovy
+++ b/vars/daosLatestVersion.groovy
@@ -31,12 +31,16 @@ String distro2repo(String distro) {
 String getLatestVersion(String distro, BigDecimal next_version, String type='stable') {
     String v = null
     String repo = 'daos-stack-daos-' + distro2repo(distro) + '-x86_64-' + type + '-local/'
+    String artifactory_url = env.ARTIFACTORY_URL
+    /* For backwards support, add the 'artifactory' path if it is missing from the env */
+    if (!artifactory_url.endsWith('/artifactory')) {
+        artifactory_url = "${artifactory_url}/artifactory"
+    }
     try {
         v = sh(label: 'Get RPM packages version for: ' + repo + ' with version < ' + next_version.toString(),
-               script: '$(command -v dnf) --refresh repoquery --repofrompath=daos,' + env.ARTIFACTORY_URL +
-                       '/artifactory/' + repo +
-                     ''' --repoid daos --qf %{version}-%{release} --whatprovides 'daos < ''' +
-                                  next_version + '''' | rpmdev-sort | tail -1''',
+               script: '$(command -v dnf) --refresh repoquery --repofrompath=daos,' + artifactory_url + '/' +
+                       repo + ''' --repoid daos --qf %{version}-%{release} --whatprovides 'daos < ''' +
+                       next_version + '''' | rpmdev-sort | tail -1''',
                returnStdout: true).trim()
     /* groovylint-disable-next-line CatchException */
     } catch (Exception e) {

--- a/vars/daosLatestVersion.groovy
+++ b/vars/daosLatestVersion.groovy
@@ -39,7 +39,7 @@ String getLatestVersion(String distro, BigDecimal next_version, String type='sta
     try {
         v = sh(label: 'Get RPM packages version for: ' + repo + ' with version < ' + next_version.toString(),
                script: '$(command -v dnf) --refresh repoquery --repofrompath=daos,' + artifactory_url + '/' +
-                       repo + ''' --repoid daos --qf %{version}-%{release} --whatprovides 'daos < ''' +
+                       repo + ''' --repoid daos --qf "%{version}-%{release}\n" --whatprovides 'daos < ''' +
                        next_version + '''' | rpmdev-sort | tail -1''',
                returnStdout: true).trim()
     /* groovylint-disable-next-line CatchException */

--- a/vars/trustedPipelineUnitTests.groovy
+++ b/vars/trustedPipelineUnitTests.groovy
@@ -1,0 +1,32 @@
+/* groovylint-disable DuplicateNumberLiteral, ParameterName, VariableName */
+// vars/trustedPipelineUnitTests.groovy
+
+  /**
+   * trustedPipelineUnitTests.groovy
+   *
+   * Runs trusted-pipeline-lib unit tests
+   */
+
+void call() {
+    // Run unit tests
+    _run_unit_tests()
+}
+
+void _run_unit_tests() {
+    // Run all the unit tests
+    println('Test daosLatestVersion()')
+    _test_daosLatestVersion("master", "el8", /2.7\.\d++.*/)
+    _test_daosLatestVersion('release/2.4', 'el8', /2.[34]\.\d++.*/)
+    _test_daosLatestVersion('release/2.6', 'el8', /2.[56]\.\d++.*/)
+}
+
+void _test_daosLatestVersion(String distro, String next_version, String expected) {
+    // Verify the version returned by daosLatestVersion() matches expected
+    println("  Running daosLatestVersion(distro=${distro}, next_version=${next_version})")
+    result =daosLatestVersion(distro, next_version)
+    println("    result:   ${result}")
+    println("    expected: ${expected}")
+    assert(result.matches(expected))
+    println("  PASSED")
+    println("")
+}

--- a/vars/trustedPipelineUnitTests.groovy
+++ b/vars/trustedPipelineUnitTests.groovy
@@ -16,7 +16,6 @@ void _run_unit_tests() {
     // Run all the unit tests
     println('Test daosLatestVersion()')
     _test_daosLatestVersion("master", "el8", /2.7\.\d++.*/)
-    _test_daosLatestVersion('release/2.4', 'el8', /2.[34]\.\d++.*/)
     _test_daosLatestVersion('release/2.6', 'el8', /2.[56]\.\d++.*/)
 }
 


### PR DESCRIPTION
A main branch has been created to keep track of all the changes needed for the FC lab.
The master branch was used to keep the old lab going.

Now that the transition process has been finished, we can switch the CI infrastructure back to the 'master' branch and get rid of the 'main' branch, which is confusing.

Requires:
- [ ] #31 